### PR TITLE
Fix RPF disconnect issue when using VCOM

### DIFF
--- a/ra4m2/src/dap_thread_entry.c
+++ b/ra4m2/src/dap_thread_entry.c
@@ -793,7 +793,12 @@ static fsp_err_t process_usb_events(usb_event_info_t *p_event_info)
         }
         else
         {
-            // Do Nothing.
+            /* ACK all other status requests */
+            err = R_USB_PeriControlStatusSet(&g_basic1_ctrl, USB_SETUP_STATUS_ACK);
+            if (FSP_SUCCESS != err)
+            {
+                ;
+            }
         }
         if (FSP_SUCCESS != err)
         {


### PR DESCRIPTION
Fix the issue when using the VCOM port to communicate with RA devices boot firmware, and the delay on disconnect.